### PR TITLE
Add newline to end of .env file in edit-env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alex-c-line",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alex-c-line",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "ISC",
       "dependencies": {
         "commander": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/commands/edit-env.ts
+++ b/src/commands/edit-env.ts
@@ -31,7 +31,10 @@ function editEnv(program: Command) {
         delete currentEnvFileContents[key];
       }
 
-      await writeFile(path.join(process.cwd(), file), dotenvStringify(currentEnvFileContents));
+      await writeFile(
+        path.join(process.cwd(), file),
+        dotenvStringify(currentEnvFileContents) + "\n",
+      );
       console.log(".env file updated");
     });
 }

--- a/tests/edit-env.test.ts
+++ b/tests/edit-env.test.ts
@@ -14,6 +14,18 @@ describe("edit-env", () => {
     await temporaryDirectoryTask(async (temporaryPath) => {
       const alexCLineTestClient = createAlexCLineTestClient({ cwd: temporaryPath });
 
+      await alexCLineTestClient("edit-env", [
+        "DATABASE_URL",
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      ]);
+      const envFileContents = await readFile(path.join(temporaryPath, ".env"), "utf-8");
+      expect(envFileContents.endsWith("\n")).toBe(true);
+    });
+  });
+  test("Adds newline to end of file", async () => {
+    await temporaryDirectoryTask(async (temporaryPath) => {
+      const alexCLineTestClient = createAlexCLineTestClient({ cwd: temporaryPath });
+
       await alexCLineTestClient("edit-env", ["PROPERTY", "hello"]);
       const envFileContents = dotenv.parse(
         await readFile(path.join(temporaryPath, ".env"), "utf-8"),


### PR DESCRIPTION
I'm petty so it has to be there.

But nah, really, it's just better for terminal output if you ever need to cat .env. Without the new line, the terminal just keeps going from that line, which doesn't look nice. If you have the new line there, the terminal prompt nicely starts on a new line.