### PR TITLE
Change version number to v1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Command-line tool with commands to streamline the developer workflow",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.8.0 (Minor Release)

**Status**: Released

This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- IT WORKED!
- This document was officially part-generated by the new `create-release-note` command! It saves so much time trying to re-create this template either purely from scratch or by copying/pasting existing notes. Now the base is already here and I can just edit the parts I need to! So much nicer!
- There are two ways to run the command:
    - As is (e.g. `alex-c-line create-release-note`):
        - This will generate a new release note in `docs/releases/(major|minor|patch)/vX.Y.Z.md`, where the third folder is determined by the type of version being released, and `vX.Y.Z.md` is named after exactly what the current version in `package.json` is.
    - With a version type argument (e.g. `alex-c-line create-release-note minor`):
        - This will generate a new release note in the same sort of directory, but now the third folder is determined by the version type provided, and the `vX.Y.Z.md` is named after what the version in `package.json` **would** be after applying that sort of increment to it.
        - Note that it does **not** change the version number in package.json. In my repositories, this is not needed anymore as it goes against the newly established publishing pattern in my packages. However, if this is still something you want to do, just run `pnpm version (major|minor|patch) --no-git-tag-show && alex-c-line create-release-note`.

## Additional Notes

- This is the most excited I have ever been about any one of these release notes so far! The fact that the feature itself generated this document is really amazing stuff!
- It's the sort of feature that will leave a massive impact on all repositories for the foreseeable future. Truly a huge turning point in my package tooling.
