### PR TITLE
Change the status to released

### DIFF
--- a/docs/releases/minor/v1.8.0.md
+++ b/docs/releases/minor/v1.8.0.md
@@ -1,6 +1,6 @@
 # v1.8.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 


### PR DESCRIPTION
Because we're about to release this, obviously.

# Documentation Change

This is a change to the documentation of `alex-c-line`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
