### PR TITLE
Change version number to v1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Command-line tool with commands to streamline the developer workflow",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.9.0 (Minor Release)

**Status**: Released

This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds a `set-release-status` command
    - If you give it a path to a release note, it will change the `**Status**: In progress` to `**Status**: Released`.
    - It also only does the first one of these (the one at the top), hence why I was able to confidently include the above in the main body. I know it won't touch this.
    - Hence, the rule for release notes now is strictly never to manually edit anything other than the body of Description of Changes and the body of the extra notes. You are likely to end up messing with the automation otherwise.

## Additional Notes

- As of now, it only changes `In progress` to `Released`. This is fine for now, but I may consider allowing you to customise the status going forward.
- In my own projects, this command is expected to be run in the `commit-version-change` GitHub Actions workflow, where it automatically commits both a version change in `package.json` and changes the corresponding release document's status.
- As such, it should now absolutely be a hard rule in my own repositories that nothing beyond the content of `Description of Changes` and `Migration Notes` or `Additional Notes` must be manually edited. Manual edits of this are likely to cause unexpected actions failures, and we know how much unexpected actions failures makes me mad by now!
