### PR TITLE
Change version number to v1.10.0

### DIFF
--- a/docs/releases/minor/v1.10.0.md
+++ b/docs/releases/minor/v1.10.0.md
@@ -1,6 +1,6 @@
 # v1.10.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Command-line tool with commands to streamline the developer workflow",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.10.0 (Minor Release)

**Status**: Released

This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds an `increment-version` command, re-adapting the `incrementVersion` utility from `@alextheman/utility` as a CLI..
- It works in more or less the same way, except instead of `omitPrefix` or `omit-prefix`, you should now use the `--no-prefix` flag to indicate you don't want the `v` prefix. This aligns better with general command-line naming conventions.

## Additional Notes

- This will be used in my next attempt to re-adapt the `commit-version-change` workflow, where it will run automatically on push to main and automatically create pull requests to change the version depending on what the next major, minor, or patch version should be, and if release notes exist for them or not.
- This will be good as it will get rid of the need to manually run the workflow, which feels a bit fiddly and error-prone. I feel like, any time a `workflow_dispatch` is a required part of a GitHub Action, it's almost always a sign to me that there is probably a more natural way to incorporate it into the development cycle.
