### PR TITLE
Change the on condition for commit-version-change

### DIFF
--- a/.github/workflows/commit-version-change.yml
+++ b/.github/workflows/commit-version-change.yml
@@ -1,20 +1,7 @@
 name: Commit a version change
 on:
-  workflow_dispatch:
-    inputs:
-      version-type:
-        description: The version type to change
-        required: true
-        type: choice
-        options:
-          - major
-          - minor
-          - patch
-        default: patch
-      message:
-        description: Release message
-        required: false
-
+  push:
+    branches: ["main"]
 
 permissions:
   contents: write
@@ -22,7 +9,7 @@ permissions:
 
 jobs:
   commit-version-change:
-    if: ${{ github.repository == 'AlexMan123456/alex-c-line' }}
-    uses: AlexMan123456/github-actions/.github/workflows/commit-version-change.yml@67ff3e75e5c0930b4598f4a188225234dda25ba9 # v2.14.0
+    if: ${{ github.repository == 'AlexMan123456/utility' }}
+    uses: AlexMan123456/github-actions/.github/workflows/commit-version-change.yml@86529c00c5698703b0d66898a7bd4fc46c7f71ff # v3.0.0
     secrets:
       PAT_GITHUB: ${{ secrets.PAT_GITHUB }}


### PR DESCRIPTION
The workflow has now been automated so it is now unnecessary to have the workflow_dispatch. It can now run on every push to main.

# Tooling Change

This is a change to the tooling of `alex-c-line`. It changes the internal workings of the package that should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
