### PR TITLE
Fix tests setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "prepare": "husky",
     "prepare-live-eslint-plugin": "pnpm uninstall @alextheman/eslint-plugin && pnpm install --save-dev @alextheman/eslint-plugin",
     "prepare-local-eslint-plugin": "dotenv -e .env -- sh -c 'ESLINT_PLUGIN_PATH=${LOCAL_ESLINT_PLUGIN_PATH:-../eslint-plugin}; pnpm --prefix \"$ESLINT_PLUGIN_PATH\" run build && pnpm uninstall @alextheman/eslint-plugin && pnpm install --save-dev file:\"$ESLINT_PLUGIN_PATH\"'",
-    "test": "vitest run",
-    "test-watch": "vitest",
+    "test": "pnpm run build && vitest run",
+    "test-watch": "pnpm run build && vitest",
     "update-dependencies": "pnpm update --latest && pnpm update",
     "use-live-eslint-plugin": "pnpm run prepare-live-eslint-plugin && pnpm run lint",
     "use-local-eslint-plugin": "pnpm run prepare-local-eslint-plugin && pnpm run lint"

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,0 @@
-// import { execa } from "execa";
-// import { beforeAll } from "vitest";
-
-// beforeAll(async () => {
-//   await execa`npm run build`;
-// });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,6 @@ import tsconfigPaths from "vite-tsconfig-paths";
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
-    setupFiles: ["/tests/setup.ts"],
     environment: "node",
     include: ["**/tests/**/*.test.ts"],
   },


### PR DESCRIPTION
First of all, I got the wrong package manager this entire time...

Second of all, I think it's better to just run the build step in the actual test script itself to guarantee that we get a freshly built package, rather than screw around with the setup file. I may've gotten away with it with NPM and/or tsup, but PNPM and tsdown don't like that as much for whatever reason. I think this approach is safer anyway as it guarantees that we only build once, at the very start of the test.

# Bug Fix

This is a bug fix for `alex-c-line`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
