### PR TITLE
Update ESLint plugin and replace all bare path and fs imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "update-notifier": "^7.3.1"
   },
   "devDependencies": {
-    "@alextheman/eslint-plugin": "^4.9.1",
+    "@alextheman/eslint-plugin": "^4.10.0",
     "@types/eslint": "^9.6.1",
     "@types/node": "^25.0.3",
     "@types/update-notifier": "^6.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         version: 7.3.1
     devDependencies:
       '@alextheman/eslint-plugin':
-        specifier: ^4.9.1
-        version: 4.9.1(@eslint/js@9.39.2)(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-import@2.32.0)(eslint-plugin-jsdoc@61.5.0(eslint@9.39.2))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2))(eslint-plugin-package-json@0.85.0(@types/estree@1.0.8)(eslint@9.39.2)(jsonc-eslint-parser@2.4.1))(eslint-plugin-perfectionist@5.0.0(eslint@9.39.2)(typescript@5.9.3))(eslint-plugin-prettier@5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint@9.39.2)(prettier@3.7.4))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2))(eslint-plugin-react-refresh@0.4.24(eslint@9.39.2))(eslint-plugin-react@7.37.5(eslint@9.39.2))(eslint@9.39.2)(typescript-eslint@8.48.1(eslint@9.39.2)(typescript@5.9.3))(typescript@5.9.3)(vite-tsconfig-paths@6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)))(vitest@4.0.16(@types/node@25.0.3))
+        specifier: ^4.10.0
+        version: 4.10.0(@eslint/js@9.39.2)(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-import@2.32.0)(eslint-plugin-jsdoc@61.5.0(eslint@9.39.2))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2))(eslint-plugin-n@17.23.1(eslint@9.39.2)(typescript@5.9.3))(eslint-plugin-package-json@0.85.0(@types/estree@1.0.8)(eslint@9.39.2)(jsonc-eslint-parser@2.4.1))(eslint-plugin-perfectionist@5.0.0(eslint@9.39.2)(typescript@5.9.3))(eslint-plugin-prettier@5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint@9.39.2)(prettier@3.7.4))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2))(eslint-plugin-react-refresh@0.4.24(eslint@9.39.2))(eslint-plugin-react@7.37.5(eslint@9.39.2))(eslint@9.39.2)(typescript-eslint@8.48.1(eslint@9.39.2)(typescript@5.9.3))(typescript@5.9.3)(vite-tsconfig-paths@6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)))(vitest@4.0.16(@types/node@25.0.3))
       '@types/eslint':
         specifier: ^9.6.1
         version: 9.6.1
@@ -72,8 +72,8 @@ importers:
 
 packages:
 
-  '@alextheman/eslint-plugin@4.9.1':
-    resolution: {integrity: sha512-pwzrNa9f2KREnSrt787to97pYWekLqscOSGsKEx6zRg8r5gTq6Po08NA1bhd/sPB78z09HxltX8VhAZRjNON8A==}
+  '@alextheman/eslint-plugin@4.10.0':
+    resolution: {integrity: sha512-9DPnyERZqbYKAHIyClr5UZQmq5Kn+Eg1aMdMSIU34TUsuJ+I8iaH5PCSbXNpHjCieKEL7qTvynjmktTGtgZQug==}
     peerDependencies:
       '@eslint/js': '>=9.0.0'
       eslint: '>=9.0.0'
@@ -82,6 +82,7 @@ packages:
       eslint-plugin-import: '>=2.0.0'
       eslint-plugin-jsdoc: '>=61.5.0'
       eslint-plugin-jsx-a11y: '>=6.0.0'
+      eslint-plugin-n: '>=17.23.1'
       eslint-plugin-package-json: '>=0.85.0'
       eslint-plugin-perfectionist: '>=4.0.0'
       eslint-plugin-prettier: '>=5.0.0'
@@ -91,9 +92,6 @@ packages:
       typescript-eslint: '>=8.0.0'
       vite-tsconfig-paths: '>=5.1.4'
       vitest: '>=4.0.13'
-
-  '@alextheman/utility@3.10.1':
-    resolution: {integrity: sha512-0hVFGxGch5nUrNPtY2np7NU28M74qOtdYzyb7Nj8Q+Ofs2PWUKvEhWwYcXh2gfbbX7duGVfMmVNWorE54mrGXw==}
 
   '@alextheman/utility@4.0.0':
     resolution: {integrity: sha512-t0rFOzgvoKB0JCO5BehAQsRT3WaqJTuNsvHf4C8xDX/zsv98ZZ35IfKDAYt0ewTikh6yvLm90J4JcUv+DEE9ug==}
@@ -1267,6 +1265,10 @@ packages:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
 
+  enhanced-resolve@5.18.4:
+    resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
+    engines: {node: '>=10.13.0'}
+
   es-abstract@1.24.1:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
     engines: {node: '>= 0.4'}
@@ -1318,6 +1320,12 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eslint-compat-utils@0.5.1:
+    resolution: {integrity: sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      eslint: '>=6.0.0'
 
   eslint-config-prettier@10.1.8:
     resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
@@ -1381,6 +1389,12 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
+  eslint-plugin-es-x@7.8.0:
+    resolution: {integrity: sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '>=8'
+
   eslint-plugin-import@2.32.0:
     resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
     engines: {node: '>=4'}
@@ -1402,6 +1416,12 @@ packages:
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+
+  eslint-plugin-n@17.23.1:
+    resolution: {integrity: sha512-68PealUpYoHOBh332JLLD9Sj7OQUDkFpmcfqt8R9sySfFSeuGJjMTJQvCRRB96zO3A/PELRLkPrzsHmzEFQQ5A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: '>=8.23.0'
 
   eslint-plugin-package-json@0.85.0:
     resolution: {integrity: sha512-MrOxFvhbqLuk4FIPG9v3u9Amn0n137J8LKILHvgfxK3rRyAHEVzuZM0CtpXFTx7cx4LzmAzONtlpjbM0UFNuTA==}
@@ -1611,6 +1631,10 @@ packages:
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@15.15.0:
+    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -2381,6 +2405,10 @@ packages:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tapable@2.3.0:
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
     engines: {node: '>=14.16'}
@@ -2417,6 +2445,11 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-declaration-location@1.0.7:
+    resolution: {integrity: sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==}
+    peerDependencies:
+      typescript: '>=4.0.0'
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -2744,9 +2777,9 @@ packages:
 
 snapshots:
 
-  '@alextheman/eslint-plugin@4.9.1(@eslint/js@9.39.2)(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-import@2.32.0)(eslint-plugin-jsdoc@61.5.0(eslint@9.39.2))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2))(eslint-plugin-package-json@0.85.0(@types/estree@1.0.8)(eslint@9.39.2)(jsonc-eslint-parser@2.4.1))(eslint-plugin-perfectionist@5.0.0(eslint@9.39.2)(typescript@5.9.3))(eslint-plugin-prettier@5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint@9.39.2)(prettier@3.7.4))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2))(eslint-plugin-react-refresh@0.4.24(eslint@9.39.2))(eslint-plugin-react@7.37.5(eslint@9.39.2))(eslint@9.39.2)(typescript-eslint@8.48.1(eslint@9.39.2)(typescript@5.9.3))(typescript@5.9.3)(vite-tsconfig-paths@6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)))(vitest@4.0.16(@types/node@25.0.3))':
+  '@alextheman/eslint-plugin@4.10.0(@eslint/js@9.39.2)(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint-import-resolver-typescript@4.4.4)(eslint-plugin-import@2.32.0)(eslint-plugin-jsdoc@61.5.0(eslint@9.39.2))(eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2))(eslint-plugin-n@17.23.1(eslint@9.39.2)(typescript@5.9.3))(eslint-plugin-package-json@0.85.0(@types/estree@1.0.8)(eslint@9.39.2)(jsonc-eslint-parser@2.4.1))(eslint-plugin-perfectionist@5.0.0(eslint@9.39.2)(typescript@5.9.3))(eslint-plugin-prettier@5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint@9.39.2)(prettier@3.7.4))(eslint-plugin-react-hooks@7.0.1(eslint@9.39.2))(eslint-plugin-react-refresh@0.4.24(eslint@9.39.2))(eslint-plugin-react@7.37.5(eslint@9.39.2))(eslint@9.39.2)(typescript-eslint@8.48.1(eslint@9.39.2)(typescript@5.9.3))(typescript@5.9.3)(vite-tsconfig-paths@6.0.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)))(vitest@4.0.16(@types/node@25.0.3))':
     dependencies:
-      '@alextheman/utility': 3.10.1
+      '@alextheman/utility': 4.0.0
       '@eslint/js': 9.39.2
       '@typescript-eslint/utils': 8.50.0(eslint@9.39.2)(typescript@5.9.3)
       common-tags: 1.8.2
@@ -2756,6 +2789,7 @@ snapshots:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2)
       eslint-plugin-jsdoc: 61.5.0(eslint@9.39.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
+      eslint-plugin-n: 17.23.1(eslint@9.39.2)(typescript@5.9.3)
       eslint-plugin-package-json: 0.85.0(@types/estree@1.0.8)(eslint@9.39.2)(jsonc-eslint-parser@2.4.1)
       eslint-plugin-perfectionist: 5.0.0(eslint@9.39.2)(typescript@5.9.3)
       eslint-plugin-prettier: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.2))(eslint@9.39.2)(prettier@3.7.4)
@@ -2769,10 +2803,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@alextheman/utility@3.10.1':
-    dependencies:
-      zod: 4.2.1
 
   '@alextheman/utility@4.0.0':
     dependencies:
@@ -3852,6 +3882,11 @@ snapshots:
 
   empathic@2.0.0: {}
 
+  enhanced-resolve@5.18.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
+
   es-abstract@1.24.1:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -3990,6 +4025,11 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-compat-utils@0.5.1(eslint@9.39.2):
+    dependencies:
+      eslint: 9.39.2
+      semver: 7.7.3
+
   eslint-config-prettier@10.1.8(eslint@9.39.2):
     dependencies:
       eslint: 9.39.2
@@ -4040,6 +4080,13 @@ snapshots:
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-es-x@7.8.0(eslint@9.39.2):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2)
+      '@eslint-community/regexpp': 4.12.2
+      eslint: 9.39.2
+      eslint-compat-utils: 0.5.1(eslint@9.39.2)
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2):
     dependencies:
@@ -4108,6 +4155,21 @@ snapshots:
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
+
+  eslint-plugin-n@17.23.1(eslint@9.39.2)(typescript@5.9.3):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.2)
+      enhanced-resolve: 5.18.4
+      eslint: 9.39.2
+      eslint-plugin-es-x: 7.8.0(eslint@9.39.2)
+      get-tsconfig: 4.13.0
+      globals: 15.15.0
+      globrex: 0.1.2
+      ignore: 5.3.2
+      semver: 7.7.3
+      ts-declaration-location: 1.0.7(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
 
   eslint-plugin-package-json@0.85.0(@types/estree@1.0.8)(eslint@9.39.2)(jsonc-eslint-parser@2.4.1):
     dependencies:
@@ -4379,6 +4441,8 @@ snapshots:
       ini: 4.1.1
 
   globals@14.0.0: {}
+
+  globals@15.15.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -5194,6 +5258,8 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
+  tapable@2.3.0: {}
+
   temp-dir@3.0.0: {}
 
   tempy@3.1.0:
@@ -5223,6 +5289,11 @@ snapshots:
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
+      typescript: 5.9.3
+
+  ts-declaration-location@1.0.7(typescript@5.9.3):
+    dependencies:
+      picomatch: 4.0.3
       typescript: 5.9.3
 
   ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3):

--- a/src/commands/check-for-file-dependencies.ts
+++ b/src/commands/check-for-file-dependencies.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 
-import { readFile } from "fs/promises";
-import path from "path";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 
 export interface PackageDependencies {
   dependencies?: Record<string, string>;

--- a/src/commands/check-lockfile-version-discrepancy.ts
+++ b/src/commands/check-lockfile-version-discrepancy.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 
-import { readFileSync } from "fs";
-import path from "path";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 function checkLockfileVersionDiscrepancy(program: Command) {
   program

--- a/src/commands/check-version-number-change.ts
+++ b/src/commands/check-version-number-change.ts
@@ -2,8 +2,8 @@ import type { Command } from "commander";
 
 import { execa } from "execa";
 
-import { readFile } from "fs/promises";
-import path from "path";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 
 import { execaNoFail } from "src/utils/execa-helpers";
 

--- a/src/commands/edit-env.ts
+++ b/src/commands/edit-env.ts
@@ -3,8 +3,8 @@ import type { Command } from "commander";
 import dotenv from "dotenv";
 import dotenvStringify from "dotenv-stringify";
 
-import { readFile, writeFile } from "fs/promises";
-import path from "path";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 
 function editEnv(program: Command) {
   program

--- a/src/commands/git-post-merge-cleanup.ts
+++ b/src/commands/git-post-merge-cleanup.ts
@@ -2,9 +2,9 @@ import type { Command } from "commander";
 
 import { execa, ExecaError } from "execa";
 
-import { readFile } from "fs/promises";
-import os from "os";
-import path from "path";
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import { createExecaClientWithDefaultOptions } from "src/utils/execa-helpers";
 

--- a/tests/check-for-file-dependencies.test.ts
+++ b/tests/check-for-file-dependencies.test.ts
@@ -2,8 +2,8 @@ import { ExecaError } from "execa";
 import { temporaryDirectoryTask } from "tempy";
 import { describe, expect, test } from "vitest";
 
-import { writeFile } from "fs/promises";
-import path from "path";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
 
 import { createAlexCLineTestClientInDirectory } from "tests/test-clients/alex-c-line-test-client";
 

--- a/tests/check-lockfile-version-discrepancy.test.ts
+++ b/tests/check-lockfile-version-discrepancy.test.ts
@@ -2,8 +2,8 @@ import { ExecaError } from "execa";
 import { temporaryDirectoryTask } from "tempy";
 import { describe, expect, test } from "vitest";
 
-import { writeFile } from "fs/promises";
-import path from "path";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
 
 import alexCLineTestClient from "tests/test-clients/alex-c-line-test-client";
 

--- a/tests/edit-env.test.ts
+++ b/tests/edit-env.test.ts
@@ -3,8 +3,8 @@ import dotenvStringify from "dotenv-stringify";
 import { temporaryDirectoryTask } from "tempy";
 import { describe, expect, test } from "vitest";
 
-import { readFile, writeFile } from "fs/promises";
-import path from "path";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 
 import { createAlexCLineTestClient } from "tests/test-clients/alex-c-line-test-client";
 

--- a/tests/git-post-merge-cleanup.test.ts
+++ b/tests/git-post-merge-cleanup.test.ts
@@ -2,8 +2,8 @@ import { execa, ExecaError } from "execa";
 import { temporaryDirectoryTask } from "tempy";
 import { describe, expect, test } from "vitest";
 
-import { readFile, writeFile } from "fs/promises";
-import path from "path";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 
 import { createAlexCLineTestClientInDirectory } from "tests/test-clients/alex-c-line-test-client";
 import {

--- a/tests/test-clients/alex-c-line-test-client.ts
+++ b/tests/test-clients/alex-c-line-test-client.ts
@@ -2,7 +2,7 @@ import type { Options } from "execa";
 
 import { execa } from "execa";
 
-import path from "path";
+import path from "node:path";
 
 async function alexCLineTestClient(command: string, args?: string[], options?: Options) {
   const localDistDirectory = path.resolve(process.cwd(), "dist");

--- a/tests/test-clients/git-testing-utilities.ts
+++ b/tests/test-clients/git-testing-utilities.ts
@@ -2,8 +2,8 @@ import type { Options } from "execa";
 
 import { execa } from "execa";
 
-import { writeFile } from "fs/promises";
-import path from "path";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
 
 export function createGitTestClient(repository: string) {
   return async (command: string, args?: string[], options?: Omit<Options, "cwd">) => {


### PR DESCRIPTION
# Tooling Change

This is a change to the tooling of `alex-c-line`. It changes the internal workings of the package that should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
