### PR TITLE
Change version number to v1.10.1

### DIFF
--- a/docs/releases/patch/v1.10.1.md
+++ b/docs/releases/patch/v1.10.1.md
@@ -1,6 +1,6 @@
 # v1.10.1 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Command-line tool with commands to streamline the developer workflow",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.10.1 (Patch Release)

**Status**: Released

This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Allows a branch name to be passed in as an argument to `git-post-merge-cleanup`.
    - I am starting to work on major features on separate major version branches now. These major version branches behave very similarly to the main branch in that they also require a pull request to merge into them.
    - As such, once a pull request gets merged into a major branch, we do still want to cleanup afterwards, however, the assumption of the command that the merge can only happen on main would not hold in this case. As such, I need to provide a way to allow for another branch name to be passed in.

## Additional Notes

- In the future (possibly the next major release), I would like to rewrite the `git-post-merge-cleanup` command further so that it can take a branch to merge from and a branch to merge to, defaulting to the current branch and main respectively if neither provided.
- Furthermore, I think the `--rebase` flag is probably another outdated assumption that should probably be replaced with `--strategy`, as we can also have a 'squash and merge' strategy even though I am not currently supporting that. Even if I don't support that (which I don't plan to for a while), just renaming the flag would at least make it clearer exactly what strategy we are using, and it does open us up to maybe adding support for it later. But again, in the next major version.
