### PR TITLE
Change version number to v1.10.2

### DIFF
--- a/docs/releases/patch/v1.10.2.md
+++ b/docs/releases/patch/v1.10.2.md
@@ -1,6 +1,6 @@
 # v1.10.2 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Command-line tool with commands to streamline the developer workflow",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.10.2 (Patch Release)

**Status**: Released

This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Replaces all cases of the old versioning utility functions from `@alextheman/utility` with its new `VersionNumber` class.
- This is a big improvement over the previous implementation that required imports from various different functions that don't share context. Now we can just import one single class that can be instantiated with a version number, and all the related helpers on the class have access to the same version number context.

## Additional Notes

- This is only a patch because it should not affect the runtime behaviour. All commands involved are expected to work exactly the same as they did before (the one to generate this document's template obviously did, as you can see!).
- See https://github.com/AlexMan123456/utility/blob/main/docs/releases/minor/v4.2.0.md for more information on the new class being used.
