### PR TITLE
Change version number to v1.10.3

### DIFF
--- a/docs/releases/patch/v1.10.3.md
+++ b/docs/releases/patch/v1.10.3.md
@@ -1,6 +1,6 @@
 # v1.10.3 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Command-line tool with commands to streamline the developer workflow",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.10.3 (Patch Release)

**Status**: Released

This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Replaces all `process.exit()` calls with `program.exit()`
    - This gets rid of the n/no-process-exit errors from eslint-plugin-n. Apparently manual `process.exit()` is bad practice and should be avoided according to them.
    - As such, my approach now is to use the built-in error method on the Commander program which automatically throws an error and sets the exit code to 1. This feels better to do in general anyway as it delegates the error handling to Commander.
    - The commander error even behaves fairly similarly to `DataError` from utility in the sense that you can provide an error code and a human-readable message, but this is better for this case as this error does not print the stack trace alongside it, unlike `DataError` which does.

## Additional Notes

- I don't think anything should've really changed as a result of me doing this. I only had to change the source code and not the tests, so it should still be giving the exact same output and so any errors you may've been trying to catch previously should still be the same.
- That said, in general, I'd recommend asserting against the error code from now on where possible as that tends to be more consistent and less likely to change then the human-readable message. If you really must assert against the human-readable message, though, keep the assertion loose using things like `.includes()` or `.toContain()` if you are in a test suite.
