### PR TITLE
Change version number to v1.12.0

### DIFF
--- a/docs/releases/minor/v1.12.0.md
+++ b/docs/releases/minor/v1.12.0.md
@@ -1,6 +1,6 @@
 # v1.12.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Command-line tool with commands to streamline the developer workflow.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.12.0 (Minor Release)

**Status**: Released

This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds a `get-version-type` command.
    - This command returns the version type (`major`, `minor`, `patch`, etc.) for a given version number.
    - The `v` prefix is optional and is handled internally via VersionNumber from the utility package.

## Additional Notes

- This will most likely be used in some of my publish workflows in my GitHub Actions repository, where I am starting to look into GitHub Releases. As such, I need this so I can point the release creation to the path that I expect the release note to be in (`docs/releases/<version-type>/<version-number>`). The output of the command would fill in the `version-type`
- It'll be nice so that the release notes can also be accessible from the main repository page itself, rather than needing to go through `docs/releases` yourself every single time.
