### PR TITLE
Change version number to v1.14.0

### DIFF
--- a/docs/releases/minor/v1.14.0.md
+++ b/docs/releases/minor/v1.14.0.md
@@ -1,6 +1,6 @@
 # v1.14.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Command-line tool with commands to streamline the developer workflow.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.14.0 (Minor Release)

**Status**: Released

This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds a few extra flags to the `pre-commit` command:
    - `--no-build`: Allows you to skip the build step.
        - Useful for repositories that don't compile their code into a `dist` folder or equivalent.
    - `--allow-unstaged`: Allows the hook to run even if there are unstaged changes.
        - The default behaviour remains the same in that it will exit early if there are no staged changes.
        - The skip is helpful when actually running pre-commits as a hook to prevent unnecessary runs that disrupt the workflow, but for those using it as a quick 'check everything' command, this is where it really shines.
