### PR TITLE
Change version number to v1.16.0

### DIFF
--- a/docs/releases/minor/v1.16.0.md
+++ b/docs/releases/minor/v1.16.0.md
@@ -1,6 +1,6 @@
 # v1.16.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Command-line tool with commands to streamline the developer workflow.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.16.0 (Minor Release)

**Status**: Released

This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds a new `pre-commit-2` command that is more config-driven.
    - The original `pre-commit` is still around but is now deprecated.
    - `pre-commit-2` is intended to eventually replace the old `pre-commit` command once the config system gets fully stabilised in v2.

## Migration Notes

- Add a `alex-c-line.config.js` file at the root of your repository.
- Use the `defineAlexCLineConfig` function to create a config object, and export it from the file.

```javascript
import { defineAlexCLineConfig } from "alex-c-line/configs";

export default defineAlexCLineConfig({
  preCommit: {
    packageManager: "pnpm",
    steps: ["format", "lint", "test"],
  },
});
```

-If you would prefer to use the AlexCLineConfig TypeScript type, `.ts` config files are not yet supported directly. As a workaround for now, use a build tool (e.g. `tsdown`) to build the file and compile it to pure JavaScript, then import from the built file. For example:

```typescript
import type { AlexCLineConfig } from "alex-c-line/configs";

import { scripts } from "package.json" with { type: "json" };

const alexCLineConfig: AlexCLineConfig<keyof typeof scripts> = {
  preCommit: {
    packageManager: "pnpm",
    steps: ["format", "lint", "test"],
  },
};

export default alexCLineConfig;
```

Your JavaScript config file may then look something like this:

```javascript
import alexCLineConfig from "./dist/config.js";

export default alexCLineConfig;
```

- I will look into proper TypeScript support in the future, but for now I think this is the best workaround.


## Additional Notes

- Despite the deprecation warnings, there is no expectation for the time being to migrate just yet. We are still in an experimental phase where the behaviour of `pre-commit-2` is experimental and may either change or not fully map onto `pre-commit` just yet.
- However, you are more than welcome to try it out and help with testing it/suggest improvements so that it can be a genuinely powerful mini pre-commit framework going forward.
