### PR TITLE
Change version number to v1.16.1

### DIFF
--- a/docs/releases/patch/v1.16.1.md
+++ b/docs/releases/patch/v1.16.1.md
@@ -1,6 +1,6 @@
 # v1.16.1 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Command-line tool with commands to streamline the developer workflow.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.16.1 (Patch Release)

**Status**: Released

This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Adds a `configs/internal` subdirectory for my own alex-c-line configs.
    - It just makes it clearer that these specific configs are more intended for my own personal use rather than as part of the public configs exports.

## Additional Notes

- I could've exported them from the ESLint plugin like I usually do with configs, however, I decided against this because I figured it'd probably be best to export the alex-c-line configs from alex-c-line itself given that I also control it.
- Internal configs exported from my ESLint plugin are meant more for actually external config systems that I intend to share across repositories, but in this case, since I actually own the repository defining the config system, it's probably best to export them from here.
- To make it clearer, I added that internal subpath. It can be thought of similarly to the `personal` config group in my ESLint plugin where it exports configs primarily for use in my own repositories, and is not recommended for use elsewhere as it has the potential to change and potentially break existing usage across even patch releases.
