### PR TITLE
Change version number to v1.17.0

### DIFF
--- a/docs/releases/minor/v1.17.0.md
+++ b/docs/releases/minor/v1.17.0.md
@@ -1,6 +1,6 @@
 # v1.17.0 (Minor Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "description": "Command-line tool with commands to streamline the developer workflow.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.17.0 (Minor Release)

**Status**: Released

This is a new minor release of the `alex-c-line` package. It introduces new features in a backwards-compatible way that should require very little refactoring, if any. Please read below the description of changes.

## Description of Changes

- Adds a command to help encrypt secrets given a base 64 key and a plaintext value.
    - This has been thoroughly tested to ensure that the plaintext value will never leak in the output logs. It will always show up in the console as an encrypted string that must be decrypted with the private key.

## Additional Notes

- This will be used to help with secret variable management in the Infrastructure repository, where we pass in an encrypted version of the secret into Terraform, along with the public key (or public key ID) so that GitHub can decrypt it to its actual value.
- It helps make secret management be more secure so that we never have to hardcode a secret variable in plaintext, making the chances of them getting leaked much lower.
