### PR TITLE
Change version number to v1.17.1

### DIFF
--- a/docs/releases/patch/v1.17.1.md
+++ b/docs/releases/patch/v1.17.1.md
@@ -1,6 +1,6 @@
 # v1.17.1 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "Command-line tool with commands to streamline the developer workflow.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.17.1 (Patch Release)

**Status**: Released

This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Renames the `encrypt` command to `encrypt-with-key`, while keeping `encrypt` as an alias.
    - This just helps to make it extra clear that we support a key-based encryption approach.
    - The previous name of `encrypt` is kept as an alias for now so that existing usage is not broken, but it may have the potential to get removed in future major versions if we do end up supporting different encryption approaches. It's not deprecated as I don't plan to remove it in v2, but worth bearing in mind.
