### PR TITLE
Change version number to v1.17.2

### DIFF
--- a/docs/releases/patch/v1.17.2.md
+++ b/docs/releases/patch/v1.17.2.md
@@ -1,6 +1,6 @@
 # v1.17.2 (Patch Release)
 
-**Status**: In progress
+**Status**: Released
 
 This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alex-c-line",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "Command-line tool with commands to streamline the developer workflow.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# v1.17.2 (Patch Release)

**Status**: Released

This is a new patch release of the `alex-c-line` package. It fixes issues with the package in a way that should require no refactoring. Please read below the description of changes.

## Description of Changes

- Use the `encryptWithKey` function from `@alextheman/utility` in the implementation of the `encrypt-with-key` command.
    - Having the logic be in utility is nice in case JavaScript or TypeScript code needs to do something like this, whereas having this command-line wrapper is nice in case I need to conveniently do something like this from the terminal without worrying about which project I'm in and/or if I need to use this in a GitHub Action.

## Additional Notes

- Utility and alex-c-line really do go together like bread and butter - we have utility providing the core functionality for commands like `encrypt-with-key`, `get-version-type`, and `increment-version`, where that core functionality can be used in JavaScript runtime environments, and then alex-c-line nicely translates the logic into something that can quickly be run from the command-line!
- It's pretty cool that we have something like this - it gets rid of the need to have all these generic developer script files per repository, instead allowing us to centralise all scripts here and reuse them not only in my projects, but also potentially anywhere else I may need them too!
