### PR TITLE
Skip the git-post-merge-cleanup rule

### DIFF
--- a/tests/commands/git-post-merge-cleanup.test.ts
+++ b/tests/commands/git-post-merge-cleanup.test.ts
@@ -14,7 +14,9 @@ import {
   setupRepository,
 } from "tests/test-clients/git-testing-utilities";
 
-describe("git-post-merge-cleanup", () => {
+// This test always takes quite a long time to complete due to the huge amounts of integration needed. Hence it has been decided that such extensive testing for a command this small is probably not worth it.
+// eslint-disable-next-line @alextheman/no-skipped-tests
+describe.skip("git-post-merge-cleanup", () => {
   test("Checks out main from the current branch, then pulls down changes and deletes the previous branch", async () => {
     await temporaryDirectoryTask(async (temporaryDirectory) => {
       // Setup


### PR DESCRIPTION
It's a long command and I feel like the tests probably not worth keeping as a result given how much they tend to slow the tests down.

# Tooling Change

This is a change to the tooling of `alex-c-line`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
