### PR TITLE
Use pnpm run command-no-build in workflows

### DIFF
--- a/.github/workflows/_commit-version-change.yml
+++ b/.github/workflows/_commit-version-change.yml
@@ -61,13 +61,13 @@ jobs:
           VERSION_TYPE: ${{ env.VERSION_TYPE }}
         id: get_next_version
         run: |
-          NEXT_VERSION=$(pnpm run command increment-version $VERSION $VERSION_TYPE)
+          NEXT_VERSION=$(pnpm run command-no-build increment-version $VERSION $VERSION_TYPE)
           echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
-          MAJOR_VERSION=$(pnpm run command get-major-version $NEXT_VERSION)
+          MAJOR_VERSION=$(pnpm run command-no-build get-major-version $NEXT_VERSION)
           echo "major_version=$MAJOR_VERSION" >> $GITHUB_OUTPUT
 
-          MINOR_VERSION=$(pnpm run command get-minor-version $NEXT_VERSION)
+          MINOR_VERSION=$(pnpm run command-no-build get-minor-version $NEXT_VERSION)
           echo "minor_version=$MINOR_VERSION" >> $GITHUB_OUTPUT
 
       - name: Find release document
@@ -142,7 +142,7 @@ jobs:
       - name: Change the status in the release document
         env:
           RELEASE_DOC_PATH: ${{ env.RELEASE_DOC_PATH }}
-        run: pnpm run command set-release-status-2 "$RELEASE_DOC_PATH"
+        run: pnpm run command-no-build set-release-status-2 "$RELEASE_DOC_PATH"
 
       - name: Mint GitHub App token
         id: app-token

--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -47,13 +47,13 @@ jobs:
           VERSION=v$(jq -r ".version" package.json)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-          MAJOR_VERSION=$(pnpm run command get-major-version $VERSION)
+          MAJOR_VERSION=$(pnpm run command-no-build get-major-version $VERSION)
           echo "major_version=$MAJOR_VERSION" >> $GITHUB_OUTPUT
 
-          MINOR_VERSION=$(pnpm run command get-minor-version $VERSION)
+          MINOR_VERSION=$(pnpm run command-no-build get-minor-version $VERSION)
           echo "minor_version=$MINOR_VERSION" >> $GITHUB_OUTPUT
 
-          VERSION_TYPE=$(pnpm run command get-version-type "$VERSION")
+          VERSION_TYPE=$(pnpm run command-no-build get-version-type "$VERSION")
           echo "version_type=$VERSION_TYPE" >> $GITHUB_OUTPUT
 
           RELEASE_DOC_PATH=docs/releases/$MAJOR_VERSION/$MINOR_VERSION/$VERSION.md

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "build": "tsdown",
     "command": "bash -c 'pnpm run build && echo && echo \"Command output:\" && node dist/index.js $@' --",
+    "command-no-build": "node dist/index.js",
     "create-release-note": "bash -c 'git pull origin main && pnpm run command create-release-note-2 $@' --",
     "format": "pnpm run format-prettier && pnpm run format-eslint",
     "format-eslint": "eslint --fix --suppress-all \"package.json\" \"src/**/*.ts\" \"tests/**/*.ts\" && rm -f eslint-suppressions.json",


### PR DESCRIPTION
It doesn't work when we include the build step beforehand for some reason.

# Bug Fix

This is a bug fix for `alex-c-line`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
