### PR TITLE
Add workflow_dispatch to create-github-release

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -1,5 +1,6 @@
 name: Create GitHub Release
 on:
+  workflow_dispatch:
   workflow_call:
     secrets:
       APP_ID:


### PR DESCRIPTION
Emergency situation - can't create the GitHub release of alex-c-line

# Bug Fix

This is a bug fix for `alex-c-line`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
