### PR TITLE
Add the workflow to restrict alex-up-bot branches from being manually…

### DIFF
--- a/.github/workflows/restrict-alex-up-bot-branches.yml
+++ b/.github/workflows/restrict-alex-up-bot-branches.yml
@@ -1,0 +1,17 @@
+name: Restrict alex-up-bot branches
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  restrict-alex-up-bot-branches:
+    uses: alextheman231/github-actions/.github/workflows/restrict-alex-up-bot-branches.yml@b4f68d2f1f14be1fc488b4bae0aaf436db239ff2 # v8.2.0
+    secrets:
+      APP_ID: ${{ secrets.ALEX_UP_BOT_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.ALEX_UP_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
… created

# Tooling Change

This is a change to the tooling of `alex-c-line`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
