### PR TITLE
Remove the -p from the manim command invocation

### DIFF
--- a/src/cli/commands/internal/media/generate.ts
+++ b/src/cli/commands/internal/media/generate.ts
@@ -24,7 +24,7 @@ function internalMediaGenerate(program: Command) {
 
           if (entry.isFile() && entry.name.endsWith(".py")) {
             console.info(`Rendering ${path.relative(process.cwd(), fullPath)}...`);
-            await execa({ stdio: "inherit" })`manim -pql ${fullPath}`;
+            await execa({ stdio: "inherit" })`manim -ql ${fullPath}`;
           }
         }
       }


### PR DESCRIPTION
This should get rid of a CI warning. It is not actually needed considering that previews don't happen in CI.

# Bug Fix

This is a bug fix for `alex-c-line`. It fixes an unintended side-effect of the package.

Please see the commits tab of this pull request for the description of changes.
