### PR TITLE
Why must we support the dumb windows thing

### DIFF
--- a/docs/releases/v2/v2.2/v2.2.2.md
+++ b/docs/releases/v2/v2.2/v2.2.2.md
@@ -1,0 +1,17 @@
+# v2.2.2 (Patch Release)
+
+<!-- alex-c-line-release-status-start -->
+**Status**: In progress
+<!-- alex-c-line-release-status-end -->
+
+<!-- alex-c-line-release-summary-start -->
+This is a new patch release of the `alex-c-line` package. It fixes issues with the package and should require no refactoring. Please read the description of changes below.
+<!-- alex-c-line-release-summary-end -->
+
+## Description of Changes
+
+<!-- user-editable-section-start -->
+- Remove the -p from the manim command invocation
+    - This should get rid of a CI warning. It is not actually needed considering that previews don't happen in CI.
+
+<!-- user-editable-section-end -->


### PR DESCRIPTION
# Documentation Change

This is a change to the documentation of `alex-c-line`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
