### PR TITLE
Add the user-editable-section-start comment

### DIFF
--- a/docs/releases/v2/v2.6/v2.6.0.md
+++ b/docs/releases/v2/v2.6/v2.6.0.md
@@ -10,6 +10,7 @@ This is a new minor release of the `alex-c-line` package. It introduces new feat
 
 ## Description of Changes
 
+<!-- user-editable-section-start -->
 - Remove the `encrypt-with-key` command
   - `libsodium-wrappers` was breaking `alex-c-line`, and the usual trick of pinning it to a known version did not work either, as all versions of it suddenly became unstable locally and in CI. Any attempts to pin it to a known version did not help either.
   - As such, I have made the decision to remove it entirely as it is only used in one command and it is not a command that is used frequently in my own workflows, and it is not worth blocking releases and other more useful commands over.


### PR DESCRIPTION
# Tooling Change

This is a change to the tooling of `alex-c-line`. It changes the internal workings of the package and should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
