### PR TITLE
Overthink a simple patch release that does nothing much

### DIFF
--- a/docs/releases/v2/v2.7/v2.7.3.md
+++ b/docs/releases/v2/v2.7/v2.7.3.md
@@ -1,0 +1,30 @@
+# v2.7.3 (Patch Release)
+
+<!-- alex-c-line-release-status-start -->
+**Status**: In progress
+<!-- alex-c-line-release-status-end -->
+
+<!-- alex-c-line-release-summary-start -->
+This is a new patch release of the `alex-c-line` package. It includes small, non-breaking changes and should require no refactoring. Please read the description of changes below.
+<!-- alex-c-line-release-summary-end -->
+
+## Description of Changes
+
+<!-- user-editable-section-start -->
+- Release to potentially fix a dependency warning.
+  - The most recent release of this package uses Zod v4.3.6 internally.
+  - However, it has recently updated to v4.4.3, and I think tsdown in Infrastructure is struggling to build the `alex-c-line` configs due to some Zod locales in v4.3.6 using CommonJS?
+  - This just does a release to ensure that the published version of this package is also using the updated dependencies.
+
+## Additional Notes
+
+- It could potentially be worth automatically creating a release the dependency updates for packages after merge?
+- Every time we update, it does mean that the underlying dependency graph has also updated, and if we don't release then there ends up being a mismatch until I next release.
+- As of now we don't automatically release after updates. I've just been going by the assumption that we only need to release if the updates broke previous functionality and needs a new release to fix it, and if we didn't need to fix the updates then we can assume functionality remains the same either way and a release isn't necessary.
+- That said, there may potentially be times where a release is needed even if it didn't change previous behaviour.
+- I think the reason I'm not doing this as of now is because of the potential mismatch we will inevitably come across. For example, if we update `alex-c-line` then release it, `alex-c-line` would need updating in `@alextheman/utility` because it is a dev dependency there. However, since all the updates generally happen around the same time frame, the `alex-c-line` release may not make it in time for the `@alextheman/utility` update.
+- Even if it does, `@alextheman/utility` is a runtime dependency in `alex-c-line` so `alex-c-line` would need updating again. Therefore meaning `@alextheman/utility` would need updating, therefore meaning... you get the idea.
+- We could maybe say that if we update a dev dependency we don't need to release, whereas if we update runtime dependencies we should release? That way, we update utility, then update `alex-c-line`, but then because `alex-c-line` is a dev dependency of utility we can get away with not needing to re-release `@alextheman/utility`?
+- As such, that would mean that we would have to schedule the updates a little more rigourously to ensure that `@alextheman/utility` and `@alextheman/components` update first, and a sufficient amount of time is allowed between their updates and `@alextheman/eslint-plugin` and `alex-c-line` to let me address issues before releasing those so they can be included in those packages' dependency updates.
+- I don't know, I think I'm probably overthinking it, to be fair. Really it's a non-issue - I can manual release updates if I come across issues.
+<!-- user-editable-section-end -->


### PR DESCRIPTION
# Documentation Change

This is a change to the documentation of `alex-c-line`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
