### PR TITLE
Release the major Commander update

### DIFF
--- a/docs/releases/v2/v2.9/v2.9.2.md
+++ b/docs/releases/v2/v2.9/v2.9.2.md
@@ -1,0 +1,18 @@
+# v2.9.2 (Patch Release)
+
+<!-- alex-c-line-release-status-start -->
+**Status**: In progress
+<!-- alex-c-line-release-status-end -->
+
+<!-- alex-c-line-release-summary-start -->
+This is a new patch release of the `alex-c-line` package. It includes small, non-breaking changes and should require no refactoring. Please read the description of changes below.
+<!-- alex-c-line-release-summary-end -->
+
+## Description of Changes
+
+<!-- user-editable-section-start -->
+- Update Commander to v15.
+  - Not much actually needed to be changed in this case, although I did have to remove explicit command options where `--no` variants existed.
+  - This is just because the presence of `--no` already implies that not providing the flag will ensure it defaults to `true`, whereas it didn't previously.
+  - That was the only error picked up on by the tests, though, so this update is not expected to cause any disruption or refactoring on your part.
+<!-- user-editable-section-end -->


### PR DESCRIPTION
It did require me to change one thing so I might as well release it.

# Documentation Change

This is a change to the documentation of `alex-c-line`. It changes the way that information about the package is presented to users.

Please see the commits tab of this pull request for the description of changes.
