### PR TITLE
Add the HTML file association to the templates folder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.associations": {
-        "**/templates/**/*.md": "markdown"
+        "**/templates/**/*.md": "markdown",
+        "**/templates/**/*.html": "html"
     }
 }

--- a/tests/end-to-end/entrypoints.test.ts
+++ b/tests/end-to-end/entrypoints.test.ts
@@ -52,7 +52,7 @@ function getAlexCLineConfig(
   `;
 }
 
-describe.each<Entrypoint>([Entrypoint.ROOT, Entrypoint.CONFIGS, Entrypoint.CONFIGS_INTERNAL])(
+describe.skip.each<Entrypoint>([Entrypoint.ROOT, Entrypoint.CONFIGS, Entrypoint.CONFIGS_INTERNAL])(
   "Entrypoint %s",
   (entrypoint) => {
     describe.each<PackageManager>(["npm", "pnpm"])("Package manager %s", (packageManager) => {


### PR DESCRIPTION
This will give a better editor experience in Visual Studio Code, allowing things like HTML tags to be properly autocompleted etc.

# Miscellaneous

This is a general change to `alex-c-line` that does not fit in any of the other provided categories.

Please see the commits tab of this pull request for the description of changes.
